### PR TITLE
Added paper_trail for change logging & auditing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.6.0'
 
 gem 'graphql', '~> 1.9.2'
+gem 'paper_trail', '~> 10.2.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.0.beta1'
 # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,9 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    paper_trail (10.2.0)
+      activerecord (>= 4.2, < 6.1)
+      request_store (~> 1.1)
     puma (3.12.0)
     rack (2.0.6)
     rack-test (1.1.0)
@@ -121,6 +124,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     ruby_dep (1.5.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -151,6 +156,7 @@ DEPENDENCIES
   byebug
   graphql (~> 1.9.2)
   listen (>= 3.0.5, < 3.2)
+  paper_trail (~> 10.2.0)
   puma (~> 3.11)
   rails (~> 6.0.0.beta1)
   spring

--- a/app/controllers/changes_controller.rb
+++ b/app/controllers/changes_controller.rb
@@ -1,0 +1,6 @@
+class ChangesController < ApplicationController
+  def index
+    @changes = PaperTrail::Version.all
+    render json: @changes
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,5 @@
 class Task < ApplicationRecord
-  has_paper_trail
+  has_paper_trail,only: [:title, :done]
   
   validates :title, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,5 @@
 class Task < ApplicationRecord
+  has_paper_trail
+  
   validates :title, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,5 @@
 class Task < ApplicationRecord
-  has_paper_trail,only: [:title, :done]
+  has_paper_trail only: [:title, :done]
   
   validates :title, presence: true
 end

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,1 @@
+PaperTrail.serializer = PaperTrail::Serializers::JSON

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   post "/graphql", to: "graphql#execute"
   resources :tasks
+  get "/changes", to: "changes#index"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20190218013423_create_versions.rb
+++ b/db/migrate/20190218013423_create_versions.rb
@@ -1,0 +1,36 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[6.0]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, {:null=>false}
+      t.integer  :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i(item_type item_id)
+  end
+end

--- a/db/migrate/20190218013424_add_object_changes_to_versions.rb
+++ b/db/migrate/20190218013424_add_object_changes_to_versions.rb
@@ -1,0 +1,12 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[6.0]
+  # The largest text column available in all supported RDBMS.
+  # See `create_versions.rb` for details.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_17_065949) do
+ActiveRecord::Schema.define(version: 2019_02_18_013424) do
 
   create_table "tasks", force: :cascade do |t|
     t.string "title"
     t.boolean "done", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.integer "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object", limit: 1073741823
+    t.datetime "created_at"
+    t.text "object_changes", limit: 1073741823
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
 end

--- a/test/controllers/changes_controller_test.rb
+++ b/test/controllers/changes_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ChangesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -10,4 +10,12 @@ class TaskTest < ActiveSupport::TestCase
     task = Task.new(title: "")
     assert_not task.save
   end
+
+  test "record changes on save" do
+    task = Task.new(title: "Hello")
+    task.save
+    assert_difference('task.versions.count') do
+      task.update(done: true)
+    end
+  end
 end


### PR DESCRIPTION
Finishes #5 

Using [paper_trail](https://github.com/paper-trail-gem/paper_trail) for change logging and auditing, since logging to DB seems more convenient than logging to files.